### PR TITLE
Allow to query files with zip extension

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -61,6 +61,7 @@ const verifyParams: RequestHandler = (req, res, next) => {
 }
 
 app.get(`${urlBase}.jar`, verifyParams, normaljar, classifierjar)
+app.get(`${urlBase}.zip`, verifyParams, normaljar, classifierjar)
 app.get(`${urlBase}.pom`, verifyParams, pom)
 
 app.get("/test/:id/:file/:classifier?", testing)

--- a/src/app.ts
+++ b/src/app.ts
@@ -61,7 +61,7 @@ const verifyParams: RequestHandler = (req, res, next) => {
 }
 
 app.get(`${urlBase}.jar`, verifyParams, normaljar, classifierjar)
-app.get(`${urlBase}.zip`, verifyParams, normaljar, classifierjar)
+app.get(`${urlBase}.zip`, verifyParams, normaljar)
 app.get(`${urlBase}.pom`, verifyParams, pom)
 
 app.get("/test/:id/:file/:classifier?", testing)


### PR DESCRIPTION
This is useful do download modpack files through CurseMaven. Currently, this is possible but only if `.jar` is used as the extension. I think allowing `.zip` as extension is a cleaner solution.